### PR TITLE
Use uri module instead of jenkins_plugins for uninstalling plugins

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -97,18 +97,16 @@
   register: _jenkins_plugins_install_result
 
 - name: Uninstall Jenkins plugins.
-  jenkins_plugin:
-    name: "{{ item.key }}"
-    jenkins_home: "{{ jenkins_plugins_jenkins_home }}"
+  uri:
+    url: "{{ jenkins_plugins_jenkins_base_url }}/pluginManager/plugin/{{ item.key }}/doUninstall"
+    timeout: "{{ jenkins_plugins_updates_timeout }}"
+    status_code: 302
+    method: POST
+    force_basic_auth: true
     url_username: "{{ jenkins_plugins_admin_username }}"
     url_password: "{{ jenkins_plugins_admin_password }}"
-    state: "{{ item.value['state'] }}"
-    timeout: "{{ jenkins_plugins_updates_timeout }}"
-    updates_url: "{{ jenkins_plugins_updates_base_url }}"
-    updates_expiration: "{{ jenkins_plugins_updates_expiration }}"
-    url: "{{ jenkins_plugins_jenkins_base_url }}"
   with_dict: "{{ jenkins_plugins_uninstall_plugins | default({}) }}"
-  changed_when: jenkins_plugins_uninstall_plugins | default({}) | length > 0
+  changed_when: _jenkins_plugins_uninstall_result.status == 302
   notify:
     - wcm_io_devops.jenkins_service restart
   register: _jenkins_plugins_uninstall_result


### PR DESCRIPTION
The `jenkins_plugin` is using GET to call the uninstall module. 
Jenkins needs a POST request for the doUninstall URL otherwise the request will be answered with an 405 Method not allowed.

Example: 

curl -v -X POST -uadmin:admin http://localhost:8080/pluginManager/plugin/pipeline-maven/doUninstall

Ansible Issue: https://github.com/ansible/ansible/pull/67385