### PR TITLE
feat: add support to change default owner and group when calling jenkins_plugin module

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ This may be necessary in proxy environments where the jenkins instance still thi
 
     jenkins_plugins_owner: "jenkins"
 
-User owning the files in the plugins folder
+User owning the files in the plugins folder.
 
     jenkins_plugins_group: "jenkins"
 
-Group owning the files in the plugins folder
+Group owning the files in the plugins folder.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ The update center proxy no proxy hosts list.
 Controls if the initial setup of the jenkins instance should be completed.
 This may be necessary in proxy environments where the jenkins instance still thinks it is in offline mode.
 
+    jenkins_plugins_owner: "jenkins"
+
+User owning the files in the plugins folder
+
+    jenkins_plugins_group: "jenkins"
+
+Group owning the files in the plugins folder
+
 ## Dependencies
 
 This role depends on the

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,3 +75,9 @@ jenkins_plugins_proxy_no_proxy_hosts: []
 # Controls if the initial setup of the jenkins instance should be completed.
 # This may be necessary in proxy environments where the jenkins instance still thinks it is in offline mode
 jenkins_plugins_complete_initial_setup: false
+
+# Owner of the files in the jenkins plugins folder
+jenkins_plugins_owner: "jenkins"
+
+# Group of the files in the jenkins plugin folder
+jenkins_plugins_group: "{{ jenkins_plugins_owner }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,6 +88,8 @@
     updates_url: "{{ jenkins_plugins_download_base_url }}"
     updates_expiration: "{{ jenkins_plugins_updates_expiration }}"
     url: "{{ jenkins_plugins_jenkins_base_url }}"
+    owner: "{{ jenkins_plugins_owner }}"
+    group: "{{ jenkins_plugins_group }}"
   with_dict: "{{ jenkins_plugins_install_plugins | default({}) }}"
   changed_when: jenkins_plugins_install_plugins | default({}) | length > 0
   notify:


### PR DESCRIPTION
The role can be used with Jenkins running on a docker container